### PR TITLE
外部キーを参照しているカラムに`onDelete('CASCADE')`追加

### DIFF
--- a/database/migrations/2022_12_11_213148_add_cascade_to_project_user_table.php
+++ b/database/migrations/2022_12_11_213148_add_cascade_to_project_user_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('project_user', function (Blueprint $table) {
+            $table->dropForeign('project_user_project_id_foreign');
+            $table->dropForeign('project_user_user_id_foreign');
+            $table->foreign('project_id')->references('id')->on('projects')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('project_user', function (Blueprint $table) {
+            $table->dropForeign('project_user_project_id_foreign');
+            $table->dropForeign('project_user_user_id_foreign');
+            $table->foreign('project_id')->references('id')->on('projects');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+};

--- a/database/migrations/2022_12_11_214843_add_cascade_to_tasks_table.php
+++ b/database/migrations/2022_12_11_214843_add_cascade_to_tasks_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropForeign('tasks_project_id_foreign');
+            $table->dropForeign('tasks_user_id_foreign');
+            $table->dropForeign('tasks_author_id_foreign');
+            $table->foreign('project_id')->references('id')->on('projects')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('author_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropForeign('tasks_project_id_foreign');
+            $table->dropForeign('tasks_user_id_foreign');
+            $table->dropForeign('tasks_author_id_foreign');
+            $table->foreign('project_id')->references('id')->on('projects');
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('author_id')->references('id')->on('users');
+        });
+    }
+};

--- a/database/migrations/2022_12_11_215027_add_cascade_to_comments_table.php
+++ b/database/migrations/2022_12_11_215027_add_cascade_to_comments_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropForeign('comments_task_id_foreign');
+            $table->dropForeign('comments_user_id_foreign');
+            $table->foreign('task_id')->references('id')->on('tasks')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropForeign('comments_task_id_foreign');
+            $table->dropForeign('comments_user_id_foreign');
+            $table->foreign('task_id')->references('id')->on('tasks');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+};

--- a/database/migrations/2022_12_11_215152_add_cascade_to_files_table.php
+++ b/database/migrations/2022_12_11_215152_add_cascade_to_files_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->dropForeign('files_task_id_foreign');
+            $table->foreign('task_id')->references('id')->on('tasks')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->dropForeign('files_task_id_foreign');
+            $table->foreign('task_id')->references('id')->on('tasks');
+        });
+    }
+};


### PR DESCRIPTION
わざわざリレーション先のレコードを消すのが面倒かつ，リレーション元のレコードが消えたレコードを残しておく必要性を感じなかったので，`onDelete('CASCADE')`を追加しました．